### PR TITLE
v0.116.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastapi" %}
-{% set version = "0.112.2" %}
+{% set version = "0.116.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3d4729c038414d5193840706907a41839d839523da6ed0c2811f1168cac1798c
+  sha256: ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143
 
 build:
   number: 0
-  # httpx and its deps (httpcore, idna) aren't available on s390x.
   # httpx is required only for testing fastapi  by using `from fastapi.testclient import TestClient`
-  skip: true  # [py<38 or s390x]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - fastapi = fastapi.cli:main
@@ -25,7 +24,7 @@ requirements:
     - pdm-backend
   run:
     - python
-    - starlette >=0.37.2,<0.39.0
+    - starlette >=0.40.0,<0.48.0
     - pydantic >=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
     - typing-extensions >=4.8.0
 


### PR DESCRIPTION
fastapi v0.116.1

**Destination channel:**  defaults

### Links

- [PKG-9289](https://anaconda.atlassian.net/browse/PKG-9289) 
- [Upstream repository](https://github.com/fastapi/fastapi/blob/0.116.1/pyproject.toml)
- [PBP](https://package-build.anaconda.com/v1/graph/6a94a909-348e-4f6d-884c-c06f0e4833cf)



[PKG-9289]: https://anaconda.atlassian.net/browse/PKG-9289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ