### PR TITLE
PKG-14088: explicit packages for fastapi multi-output feedstock

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -2,3 +2,7 @@ anaconda_config_version: 1
 upstream_sources:
   - pypi:
       identifier: fastapi
+    packages:
+      - fastapi-core
+      - fastapi
+      - fastapi-all


### PR DESCRIPTION
## Summary
Add explicit `packages` for `fastapi-core`, `fastapi`, and `fastapi-all` (matches recipe outputs; PyPI source remains `fastapi`).

## Ticket
PKG-14088

Made with [Cursor](https://cursor.com)