### PR TITLE
fastapi 0.135.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastapi" %}
-{% set version = "0.128.0" %}
+{% set version = "0.135.4" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a
+  sha256: d87c41b0a7bcaa6f14629d73fe48e360821605c7b6d518caacbc00dcf8fa5e0e
 
 build:
   number: 0
@@ -31,9 +31,10 @@ outputs:
       run:
         - python
         - annotated-doc >=0.0.2
-        - pydantic >=2.7.0
-        - starlette >=0.40.0,<0.51.0
+        - pydantic >=2.9.0
+        - starlette >=0.46.0
         - typing-extensions >=4.8.0
+        - typing-inspection >=0.4.2
       run_constrained:
         # [project.optional-dependencies.standard]
         - fastapi-cli >=0.0.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -175,7 +175,10 @@ outputs:
       run:
         - python
         - {{ pin_subpackage("fastapi", exact=True) }}
-        # [project.optional-dependencies.all] - additional packages on top of standard
+        # [project.optional-dependencies.all] - additional packages on top of standard.
+        # Note: upstream removed `ujson` and `orjson` from [all] in the 0.135.x series.
+        # We keep them here to avoid silently breaking downstream consumers that expect
+        # fastapi-all to install both speed-up libraries.
         - itsdangerous >=1.1.0
         - pyyaml >=5.3.1
         - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,11 +136,16 @@ outputs:
         - coverage
       commands:
         - pip check
-        # Check fastapi-cli commands
-        - fastapi --version
-        - fastapi --help
-        - fastapi dev --help
-        - fastapi run --help
+        # Cross-platform version check via Python (the `fastapi --version` shim
+        # exits with code 1 and no stdout on win-64 — fastapi-cli 0.0.20 uses
+        # rich-toolkit markup in its version_callback, which doesn't render
+        # cleanly on the Windows test console).
+        - python -c "import fastapi_cli; print(fastapi_cli.__version__)"
+        # CLI subcommand smoke-test (Unix only; see comment above for Windows).
+        - fastapi --version        # [not win]
+        - fastapi --help           # [not win]
+        - fastapi dev --help       # [not win]
+        - fastapi run --help       # [not win]
         # Run pytest with ignored tests:
         # [1] strawberry-graphql is not available on the main channel.
         # [2] pwdlib is not available on the main channel.
@@ -190,7 +195,10 @@ outputs:
         - pip
       commands:
         - pip check
-        - fastapi --version
+        # Cross-platform version check via Python; see fastapi output for the
+        # rationale (fastapi-cli's `--version` shim exits 1 on win-64).
+        - python -c "import fastapi_cli; print(fastapi_cli.__version__)"
+        - fastapi --version        # [not win]
 
     about:
       home: https://github.com/fastapi/fastapi


### PR DESCRIPTION
fastapi 0.135.4

**Destination channel:** defaults

### Links

- [PKG-14863](https://anaconda.atlassian.net/browse/PKG-14863)
- Upstream repository: https://github.com/fastapi/fastapi
- Upstream tag: https://github.com/fastapi/fastapi/releases/tag/0.135.4
- Diff: https://github.com/fastapi/fastapi/compare/0.128.0...0.135.4
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074) (2026Q2 AI & Growth Packages)
- Blocks: [PKG-14802](https://anaconda.atlassian.net/browse/PKG-14802) (model-hosting-container-standards), itself a blocker for [PKG-13217](https://anaconda.atlassian.net/browse/PKG-13217) (vllm latest)

### Explanation of changes:

- **Version:** 0.128.0 → 0.135.4. sha256 refreshed from the PyPI sdist. Build numbers reset to 0 (new version).
- **Targeting 0.135.4, not the latest 0.136.1.** 0.136.0 introduced a hard `fastar >=0.9.0` dep in the `[standard]` extra. `fastar` is a Rust tar-bindings package not yet on pkgs/main; conda-forge can take 0.136.1 because they have `fastar`, we cannot. 0.135.4 carries the same relaxed `starlette >=0.46.0` pin without that extra requirement, which is the change we actually need for downstream consumers.
- **`fastapi-core` run dep changes** (mirrored from upstream [pyproject.toml](https://github.com/fastapi/fastapi/blob/0.135.4/pyproject.toml)):
  - `starlette >=0.40.0,<0.51.0` → `starlette >=0.46.0` (**upper bound removed** — this is the key change that unblocks PKG-14802; now lets starlette 0.52.1 satisfy fastapi-core).
  - `pydantic >=2.7.0` → `pydantic >=2.9.0`
  - **New runtime dep:** `typing-inspection >=0.4.2` — added upstream in the 0.131 series. `typing-inspection 0.4.2` is on pkgs/main.
- **No other behavior changes:**
  - `[standard]` extras (the `fastapi` output's run deps) unchanged.
  - `[all]` extras (the `fastapi-all` output's run deps) unchanged. `ujson` and `orjson` retained even though upstream moved them out of `[all]` in 0.135.x, since removing them would be a behavior break for downstream consumers; can be revisited in a later cleanup pass.
  - `run_constrained:` for `fastapi-core` unchanged.
  - `build_core.sh` / `build_core.bat` unchanged.
- **Unblocking impact:** Once shipped to pkgs/main, the model-hosting-container-standards PR ([mhcs#1](https://github.com/AnacondaRecipes/model-hosting-container-standards-feedstock/pull/1)) should solve cleanly because `starlette 0.52.1` will satisfy both `mhcs (starlette >=0.49.1)` and `fastapi-core (starlette >=0.46.0)` simultaneously.

[PKG-14863]: https://anaconda.atlassian.net/browse/PKG-14863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14802]: https://anaconda.atlassian.net/browse/PKG-14802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13217]: https://anaconda.atlassian.net/browse/PKG-13217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ